### PR TITLE
OPENEUROPA-315: Rename configuration in OE Theme to use namespace oe.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,25 +45,18 @@
             "Drupal\\Tests\\oe_theme\\": "tests"
         }
     },
-    "repositories": [
-        {
+    "repositories": {
+        "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/openeuropa/oe_paragraphs"
         }
-    ],
+    },
     "extra": {
         "patches": {
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/474684": "https://www.drupal.org/files/issues/474684-151.patch",
                 "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2943172-kernel-test-base.patch"
             }
-        },
-        "branch-alias": {
-            "oe-315": "dev-OPENEUROPA-315-name_prefix"
         },
         "installer-paths": {
             "build/core": ["type:drupal-core"],

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "composer/installers": "^1.2",
         "drupal/console": "^1",
         "drupal/config_devel": "~1.2",
-        "openeuropa/oe_paragraphs": "dev-master",
+        "openeuropa/oe_paragraphs": "dev-OPENEUROPA-315-name_prefix",
         "drush/drush": "^9",
         "drupal/core": "^8.5",
         "mikey179/vfsStream": "^1.2",
@@ -45,18 +45,25 @@
             "Drupal\\Tests\\oe_theme\\": "tests"
         }
     },
-    "repositories": {
-        "drupal": {
+    "repositories": [
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/openeuropa/oe_paragraphs"
         }
-    },
+    ],
     "extra": {
         "patches": {
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/474684": "https://www.drupal.org/files/issues/474684-151.patch",
                 "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2943172-kernel-test-base.patch"
             }
+        },
+        "branch-alias": {
+            "oe-315": "dev-OPENEUROPA-315-name_prefix"
         },
         "installer-paths": {
             "build/core": ["type:drupal-core"],

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -32,12 +32,12 @@ function oe_theme_theme_suggestions_field_alter(array &$suggestions, array $vari
 /**
  * Implements hook_preprocess_paragraph().
  */
-function oe_theme_preprocess_paragraph__oe_paragraphs_links_block(&$variables) {
+function oe_theme_preprocess_paragraph__oe_links_block(&$variables) {
   // Massage data to be compliant with ECL links block component data structure.
-  foreach (Element::children($variables['content']['field_oe_paragraphs_links']) as $index) {
+  foreach (Element::children($variables['content']['field_oe_links']) as $index) {
     $variables['links'][] = [
-      'label' => $variables['content']['field_oe_paragraphs_links'][$index]['#title'],
-      'href' => $variables['content']['field_oe_paragraphs_links'][$index]['#url'],
+      'label' => $variables['content']['field_oe_links'][$index]['#title'],
+      'href' => $variables['content']['field_oe_links'][$index]['#url'],
     ];
   }
 }

--- a/templates/paragraphs/paragraph--oe-links-block.html.twig
+++ b/templates/paragraphs/paragraph--oe-links-block.html.twig
@@ -39,6 +39,6 @@
  */
 #}
 {% include '@ecl/ecl-link-blocks' with {
-  'title': content.field_oe_paragraphs_text,
+  'title': content.field_oe_text,
   'links': links,
 } %}

--- a/tests/Kernel/ParagraphsTest.php
+++ b/tests/Kernel/ParagraphsTest.php
@@ -47,7 +47,7 @@ class ParagraphsTest extends AbstractKernelTest {
     $paragraph = Paragraph::create([
       'type' => 'oe_links_block',
       'field_oe_text' => 'Title',
-      'field_oe _links' => [
+      'field_oe_links' => [
         [
           'title' => 'Link 1',
           'uri' => 'internal:/',

--- a/tests/Kernel/ParagraphsTest.php
+++ b/tests/Kernel/ParagraphsTest.php
@@ -45,9 +45,9 @@ class ParagraphsTest extends AbstractKernelTest {
    */
   public function testLinksBlock() {
     $paragraph = Paragraph::create([
-      'type' => 'oe_paragraphs_links_block',
-      'field_oe_paragraphs_text' => 'Title',
-      'field_oe_paragraphs_links' => [
+      'type' => 'oe_links_block',
+      'field_oe_text' => 'Title',
+      'field_oe _links' => [
         [
           'title' => 'Link 1',
           'uri' => 'internal:/',


### PR DESCRIPTION
The configuration in OE Paragraphs has been updated, so the namespacing for all fields and derivates will be prefixed by "oe" instead of "oe_paragraphs".

This PR update the theme to be inline with oe_paragraphs fields!